### PR TITLE
Unable to install logitech_options because of mismatching fileextensions

### DIFF
--- a/Apps/logitech_options.json
+++ b/Apps/logitech_options.json
@@ -5,7 +5,7 @@
   "url": "https://intunebrew.blob.core.windows.net/pkg/logitech_options_1.86.669369.pkg",
   "bundleId": "com.logitech.Logi-Options",
   "homepage": "https://www.logitech.com/en-us/software/logi-options-plus.html",
-  "fileName": "logioptionsplus_installer.zip",
+  "fileName": "logioptionsplus_installer.pkg",
   "type": "app",
   "sha": "c3d84b604d55baf730594b3a417390d94acccf0932c8e9794ece953c421b40f1",
   "changelog": "https://support.logi.com/hc/articles/1500005516462",


### PR DESCRIPTION
Updated file extension: Property "filename" in configuration json of logitech_options should be .pkg instead of .zip to be able to install the app using IntuneBrew. The URL property points to .pkg URL of IntuneBrews storage account which is correct. But after the file is downloaded, it is stored as .zip file on the local disk. Therefore the deployment script is unable to upload the file even though the binary data would be pkg content.