### PR TITLE
Add Maintainer for automated issue triage

### DIFF
--- a/.github/maintainer.yml
+++ b/.github/maintainer.yml
@@ -1,0 +1,23 @@
+# Maintainer config for IntuneBrew
+# https://github.com/ugurkocde/Maintainer
+
+triage:
+  enabled: true
+  auto_label: true
+  auto_dedupe: true
+
+fix:
+  enabled: true
+  # Conservative default for the first repo: only attempt fixes
+  # when explicitly invoked via `/maintainer fix` or `@maintainer fix this`.
+  auto_attempt: false
+
+commands:
+  enabled: true
+  require_write_permission: true
+
+stale:
+  enabled: true
+  days_until_stale: 90
+  days_until_close: 14
+  exempt_labels: [pinned, security, enhancement]

--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -1,0 +1,23 @@
+name: Maintainer
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ugurkocde/maintainer@v1
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Installs [Maintainer](https://github.com/ugurkocde/Maintainer) as a GitHub Action.
- Triages new issues automatically: classification, severity, scope, duplicate detection, labels, summary comment.
- Enables slash commands (`/maintainer fix`, `/maintainer triage`, `/maintainer skip`, etc.) and free-form `@maintainer` natural-language requests.
- Schedules a weekly stale-issue sweep (Mondays 09:00 UTC).
- Auto-fix is **disabled** for this initial install. Fix attempts require explicit invocation via \`/maintainer fix\` or \`@maintainer fix this\`.

## Required before merging

Set \`ANTHROPIC_API_KEY\` as a repository secret (or organization secret) under **Settings -> Secrets and variables -> Actions**. Without it, the workflow will fail on the first run.

## Test plan

- [ ] Verify CI passes on this PR.
- [ ] Set \`ANTHROPIC_API_KEY\` secret.
- [ ] Merge.
- [ ] Open a test issue and confirm Maintainer posts a triage comment within ~60 seconds.
- [ ] Try \`/maintainer help\` in a comment.
- [ ] Try \`@maintainer take a look at this\` in a comment.
- [ ] If satisfied, flip \`fix.auto_attempt\` to \`true\` in \`.github/maintainer.yml\` to enable automatic fix-PR drafting for scoped reproducible bugs.