### PR TITLE
Fix: Trailing whitespace in app name causes silent assignment failure

### DIFF
--- a/IntuneBrew.ps1
+++ b/IntuneBrew.ps1
@@ -1631,14 +1631,16 @@ function Get-FormattedAppName {
         [string]$Suffix
     )
 
-    $formattedName = $BaseName
+    # Trim incoming components so stray whitespace (e.g. "Slack ") does not
+    # silently break Intune lookups, group assignments, or logo URL resolution.
+    $formattedName = if ($null -ne $BaseName) { $BaseName.Trim() } else { '' }
     if (-not [string]::IsNullOrEmpty($Prefix)) {
-        $formattedName = $Prefix + $formattedName
+        $formattedName = $Prefix.Trim() + $formattedName
     }
     if (-not [string]::IsNullOrEmpty($Suffix)) {
-        $formattedName = $formattedName + $Suffix
+        $formattedName = $formattedName + $Suffix.Trim()
     }
-    return $formattedName
+    return $formattedName.Trim()
 }
 # Retrieves and compares app versions between Intune and GitHub
 function Get-IntuneApp {


### PR DESCRIPTION
Fixes #193

## Summary

Trims whitespace from app name components in \`Get-FormattedAppName\` so stray trailing spaces in display names do not silently break Intune lookups, group assignments, or logo URL resolution.

## Files changed

- \`IntuneBrew.ps1\`

## Notes

Drafted by Maintainer on commit \`maintainer/fix-193\`. The Action's automatic PR creation step was blocked by the previous repo permission setting, so this PR was opened manually from the agent's pushed branch. Future runs will open the PR automatically now that the setting is on.

This pull request is opened as a draft and labeled \`maintainer:needs-human-review\`. Review the diff before marking it ready.