### PR TITLE
Fix Codex cask catalog collision

### DIFF
--- a/.github/scripts/collect_app_info.py
+++ b/.github/scripts/collect_app_info.py
@@ -481,7 +481,6 @@ app_urls = [
     "https://formulae.brew.sh/api/cask/sipgate.json",
     "https://formulae.brew.sh/api/cask/support.json",
     "https://formulae.brew.sh/api/cask/thaw.json",
-    "https://formulae.brew.sh/api/cask/codex.json",
 ]
 
 # DMG

--- a/Apps/codex.json
+++ b/Apps/codex.json
@@ -1,8 +1,8 @@
 {
   "name": "Codex",
   "description": "OpenAI's Codex desktop app for managing coding agents",
-  "version": "0.146.0",
-  "url": "https://github.com/openai/codex/releases/download/rust-v0.146.0/codex-aarch64-apple-darwin.tar.gz",
+  "version": "26.623.141536",
+  "url": "https://intunebrew.blob.core.windows.net/pkg/codex_26.623.141536.pkg",
   "vendor_url": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.623.81905.zip",
   "bundleId": "com.openai.codex",
   "homepage": "https://openai.com/codex",
@@ -11,6 +11,8 @@
   "category": "Developer Tools",
   "publisher": "OpenAI",
   "previous_version": "26.623.141536",
-  "sha": "2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e",
-  "homebrew_cask": "codex"
+  "sha": "6eca51da02b3c9dd211c22f0a772289ed7fc92b74955d2acec98d8c3279bac98",
+  "homebrew_cask": "codex-app",
+  "deprecated": true,
+  "deprecation_reason": "deprecated in Homebrew: discontinued"
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     </a>
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       <p>
     <a href="#-supported-applications">
-      <img src="https://img.shields.io/badge/Apps_Available-1151-2ea44f?style=flat" alt="TotalApps"/>
+      <img src="https://img.shields.io/badge/Apps_Available-1150-2ea44f?style=flat" alt="TotalApps"/>
     </a>
   </p>
 </div>
@@ -580,7 +580,6 @@ This project uses publicly available metadata from Homebrew’s JSON API. Homebr
 | Dash | 8.1.1 | 23.1.7 |
 | Google Antigravity | 2.4.2 | 2.4.3 |
 | MacPacker | 0.18.0 | 0.18.1 |
-| Codex | 26.623.141536 | 0.146.0 |
 | ChatWise | 26.7.4 | 26.7.5 |
 | Headlamp | 0.43.0 | 0.44.0 |
 | Canva | 1.123.0 | 1.123.1 |
@@ -855,7 +854,6 @@ This project uses publicly available metadata from Homebrew’s JSON API. Homebr
 | <img src='Logos/coconutbattery.png' width='32' height='32'> coconutBattery | 4.3.3 |
 | <img src='Logos/codeedit.png' width='32' height='32'> CodeEdit | 0.3.6 |
 | <img src='Logos/coderunner.png' width='32' height='32'> CodeRunner | 4.5 |
-| <img src='Logos/codex.png' width='32' height='32'> Codex | 0.146.0 |
 | <img src='Logos/coherence_x.png' width='32' height='32'> Coherence X | 5.1.3 |
 | <img src='Logos/colorsnapper_2.png' width='32' height='32'> ColorSnapper 2 | 1.7.1 |
 | <img src='Logos/colorwell.png' width='32' height='32'> ColorWell | 8.1.5 |

--- a/supported_apps.json
+++ b/supported_apps.json
@@ -207,7 +207,6 @@
     "coconutbattery": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/coconutbattery.json",
     "codeedit": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/codeedit.json",
     "coderunner": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/coderunner.json",
-    "codex": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/codex.json",
     "coherence_x": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/coherence_x.json",
     "colorsnapper_2": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/colorsnapper_2.json",
     "colorwell": "https://raw.githubusercontent.com/ugurkocde/IntuneBrew/main/Apps/colorwell.json",

--- a/tests/test_collect_app_info.py
+++ b/tests/test_collect_app_info.py
@@ -612,6 +612,18 @@ class CalculateFileHashTests(unittest.TestCase):
 
 
 class CatalogConsistencyTests(unittest.TestCase):
+    def test_codex_uses_desktop_cask_instead_of_cli_cask(self):
+        desktop_url = "https://formulae.brew.sh/api/cask/codex-app.json"
+        cli_url = "https://formulae.brew.sh/api/cask/codex.json"
+
+        self.assertIn(desktop_url, collect_app_info.app_urls)
+        self.assertNotIn(cli_url, collect_app_info.app_urls)
+
+        codex = json.loads(
+            (ROOT / "Apps" / "codex.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(codex["homebrew_cask"], "codex-app")
+
     def test_supported_catalog_matches_non_deprecated_apps(self):
         apps = {
             path.stem: json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- remove the non-deployable Codex CLI cask from the app collector
- restore `Apps/codex.json` to the Codex desktop app metadata
- keep the discontinued desktop cask out of the supported-app catalog
- add regression coverage preventing the CLI cask from being reintroduced

## Validation

- 33 Python tests pass
- 1,281 catalog JSON files parse successfully
- full collector run completes successfully across 1,256 prefetched casks